### PR TITLE
make definition for RPR_AOV_MAX in plugin since it was removed from SDK

### DIFF
--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -41,6 +41,8 @@ limitations under the License.
 
 //#define FRW_LOGGING 1
 
+#define RPR_AOV_MAX 0x20
+
 #if FRW_LOGGING
 
 #define FRW_PRINT_DEBUG DebugPrint


### PR DESCRIPTION
PURPOSE:
RPR_AOV_MAX macro  was removed  from Core SDK

EFFECT OF CHANGES:
Temporary define this macro in plugin to be able to compile the plugin