### PR TITLE
RemapHSV node native implementation

### DIFF
--- a/FireRender.Maya.Src/MayaStandardNodesSupport/RemapHSVConverter.cpp
+++ b/FireRender.Maya.Src/MayaStandardNodesSupport/RemapHSVConverter.cpp
@@ -10,6 +10,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ********************************************************************/
+
+#include <maya/MRampAttribute.h>
+
 #include "RemapHSVConverter.h"
 #include "FireMaya.h"
 
@@ -17,7 +20,69 @@ MayaStandardNodeConverters::RemapHSVConverter::RemapHSVConverter(const Converter
 {
 }
 
+frw::Value MayaStandardNodeConverters::RemapHSVConverter::GetSamplerNodeForForPlugName(const MString& plugName, frw::Value valueInput) const
+{
+	MPlug plug = m_params.shaderNode.findPlug(plugName, false);
+
+	if (plug.isNull())
+	{
+		assert(!"RemapHSV parse. Error: could not get the plug");
+		return frw::Value();
+	}
+
+	const unsigned int bufferSize = 256; // same as in Blender
+
+	// create buffer desc
+	rpr_buffer_desc bufferDesc;
+	bufferDesc.nb_element = bufferSize;
+	bufferDesc.element_type = RPR_BUFFER_ELEMENT_TYPE_FLOAT32;
+	bufferDesc.element_channel_size = 3;
+
+	std::vector<float> arrData(bufferDesc.element_channel_size * bufferSize);
+
+	MRampAttribute rampAttr(plug);
+
+	for (size_t index = 0; index < bufferSize; ++index)
+	{
+		float val = 0.0f;
+		rampAttr.getValueAtPosition((float)index / (bufferSize - 1), val);
+
+		for (unsigned int j = 0; j < bufferDesc.element_channel_size; ++j)
+		{
+			arrData[bufferDesc.element_channel_size * index + j] = val;
+		}
+	}
+
+	// create buffer
+	frw::DataBuffer dataBuffer(m_params.scope.Context(), bufferDesc, arrData.data());
+
+	frw::Value arithmeticValue = valueInput * (float)bufferSize;
+
+	// create buffer node
+	frw::BufferNode bufferNode(m_params.scope.MaterialSystem());
+	bufferNode.SetBuffer(dataBuffer);
+	bufferNode.SetUV(arithmeticValue);
+
+	return bufferNode;
+}
+
 frw::Value MayaStandardNodeConverters::RemapHSVConverter::Convert() const
 {
-	return m_params.scope.createImageFromShaderNodeUsingFileNode(m_params.shaderNode.object(), MString("outColor"));
+	frw::RGBToHSVNode rgbToHSVNode(m_params.scope.MaterialSystem());
+
+	frw::Value rgbInput = m_params.scope.GetValue(m_params.shaderNode.findPlug("color", false));
+	rgbToHSVNode.SetInputColor(rgbInput);
+
+	frw::Value hsvInput = rgbToHSVNode;
+
+	frw::Value hueOutput = GetSamplerNodeForForPlugName("hue", hsvInput.SelectX());
+	frw::Value saturationOutput = GetSamplerNodeForForPlugName("saturation", hsvInput.SelectY());
+	frw::Value valueOutput = GetSamplerNodeForForPlugName("value", hsvInput.SelectZ());
+	frw::Value hsvRemapped = m_params.scope.MaterialSystem().ValueCombine(hueOutput, saturationOutput, valueOutput);
+
+	frw::HSVToRGBNode hsvToRGBNode(m_params.scope.MaterialSystem());
+
+	hsvToRGBNode.SetInputColor(hsvRemapped);
+
+	return hsvToRGBNode;
 }

--- a/FireRender.Maya.Src/MayaStandardNodesSupport/RemapHSVConverter.h
+++ b/FireRender.Maya.Src/MayaStandardNodesSupport/RemapHSVConverter.h
@@ -22,6 +22,9 @@ namespace MayaStandardNodeConverters
 	public:
 		RemapHSVConverter(const ConverterParams& params);
 		virtual frw::Value Convert() const override;
+
+	private:
+		frw::Value GetSamplerNodeForForPlugName(const MString& plugName, frw::Value valueInput) const;
 	};
 
 }

--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -157,7 +157,9 @@ namespace frw
         ValueTypeAOMap = RPR_MATERIAL_NODE_AO_MAP,
 		ValueTypeUVProcedural = RPR_MATERIAL_NODE_UV_PROCEDURAL,
 		ValueTypeUVTriplanar = RPR_MATERIAL_NODE_UV_TRIPLANAR,
-		ValueTypeBufferSampler = RPR_MATERIAL_NODE_BUFFER_SAMPLER // buffer node
+		ValueTypeBufferSampler = RPR_MATERIAL_NODE_BUFFER_SAMPLER, // buffer node
+		ValueTypeHSVToRGB = RPR_MATERIAL_NODE_HSV_TO_RGB,
+		ValueTypeRRGToHSV = RPR_MATERIAL_NODE_RGB_TO_HSV
 	};
 
 	enum ShaderType
@@ -2332,6 +2334,28 @@ namespace frw
 				auto res = rprMaterialNodeSetInputNByKey(Handle(), RPR_MATERIAL_INPUT_COLOR, n.Handle());
 				checkStatus(res);
 			}
+		}
+	};
+
+	class RGBToHSVNode : public ValueNode
+	{
+	public:
+		explicit RGBToHSVNode(const MaterialSystem& h) : ValueNode(h, ValueTypeRRGToHSV) {}
+
+		void SetInputColor(const Value& inputRGB)
+		{
+			SetValue(RPR_MATERIAL_INPUT_COLOR, inputRGB);
+		}
+	};
+
+	class HSVToRGBNode : public ValueNode
+	{
+	public:
+		explicit HSVToRGBNode(const MaterialSystem& h) : ValueNode(h, ValueTypeHSVToRGB) {}
+
+		void SetInputColor(const Value& inputHSV)
+		{
+			SetValue(RPR_MATERIAL_INPUT_COLOR, inputHSV);
 		}
 	};
 


### PR DESCRIPTION
TCIKET: RPRMAYA-1936

PURPOSE:
Baking RemapHSV gets very long time

EFFECT OF CHANGES:
Plugin supports RemapHSV natively by using RPR's nodes