### PR TITLE
Material node connection to transform node related fix

### DIFF
--- a/FireRender.Maya.Src/FireMaya.cpp
+++ b/FireRender.Maya.Src/FireMaya.cpp
@@ -81,8 +81,13 @@ MPlug FireMaya::GetConnectedPlug(const MPlug& plug)
 		plug.connectedTo(connections, true, false);
 		if (connections.length() > 0)
 		{
-			if (!connections[0].node().hasFn(MFn::kAnimCurve))
+			MObject objNode = connections[0].node();
+
+			if (!objNode.hasFn(MFn::kAnimCurve) && 
+				!objNode.hasFn(MFn::kTransform))
+			{
 				return connections[0];
+			}
 		}
 	}
 	return MPlug();


### PR DESCRIPTION
TICKET RPRMAYA-2157

PURPOSE:
RPR in Maya crashes when material node has connection to transform node

EFFECT OF CHANGES:
RPR is stable on parsing such material graphs.