### PR TITLE
Move to fixed version of Rif 1.5.1.2 (symbolic links problem)

### DIFF
--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -41,6 +41,8 @@ limitations under the License.
 
 //#define FRW_LOGGING 1
 
+#define RPR_AOV_MAX 0x20
+
 #if FRW_LOGGING
 
 #define FRW_PRINT_DEBUG DebugPrint


### PR DESCRIPTION
PURPOSE:
Latest Rif has issue: dylib files fo OSX has no symbolic links, just usual files (which might be treated as corrupted since they have 20-30 bytes in size)

EFFECT OF CHANGE:
Use  submodule link to fixed version of Rif