### PR TITLE
Dmotor/handle missing render layer in export

### DIFF
--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -704,9 +704,8 @@ bool isTransformWithInstancedShape(const MObject& node, MDagPath& nodeDagPath)
 		transformNode.getAllPaths(pathArrayToTransform);
 	}
 
-	assert(pathArrayToTransform.length() == 1);
-
-	if (pathArrayToTransform.length() != 1)
+	int pathArrayLength = pathArrayToTransform.length();
+	if (pathArrayLength == 0)
 		return false;
 
 	// get shape (referenced by transform)

--- a/FireRender.Maya.Src/scripts/shelfCommands.mel
+++ b/FireRender.Maya.Src/scripts/shelfCommands.mel
@@ -143,7 +143,7 @@ global proc launchSceneExport()
 		int $framePadding = `getAttr defaultRenderGlobals.extensionPadding`;
 		string $selectedCam = `optionMenu -query -value selectedCamera`;
 
-		catch ( `OxSetIsRendering(true)` );
+		catchQuiet ( `OxSetIsRendering(true)` );
 
 		fireRenderExport 
 			-scene 
@@ -153,7 +153,7 @@ global proc launchSceneExport()
 			-padding $namePattern $framePadding
 			-camera $selectedCam;
 
-		catch ( `OxSetIsRendering(false)` );
+		catchQuiet ( `OxSetIsRendering(false)` );
 
 	}
 
@@ -296,13 +296,18 @@ global proc exportSceneRPR()
 				$layers = `ls -type "renderLayer"`;
 				for( $layer in $layers )
 				{
-					editRenderLayerGlobals -currentRenderLayer $layer;     
-					string $camerasShapes[] = `ls -type camera`;
-					string $cameras[] = `listRelatives -p $camerasShapes`;
-					for ($camera in $cameras)
+					if (catch ( `editRenderLayerGlobals -currentRenderLayer $layer` ))
 					{
-						menuItem 
-							-label $camera;
+						print("cant use layer ");
+						print($layer);
+					} else {
+						string $camerasShapes[] = `ls -type camera`;
+						string $cameras[] = `listRelatives -p $camerasShapes`;
+						for ($camera in $cameras)
+						{
+							menuItem 
+								-label $camera;
+						}	
 					}
 				}
 


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2145

PURPOSE: Currently School_Hall scene from RE team is filing to export.

EFFECT FOR THE USER: Scene getting exported normally.

TECHINCAL DETAILS: This issue happens because they got render settings layer imported together with some geometry from referenced scene and script tries using this render settings when searching for cameras that can be used during the export. Unfortunately editRenderLayerGlobals mel command crashes the script instead of returning error, so I had to wrap it in catch(…) block.

NOTE FOR REVIWERS: As part of this PR I also fixed to small issues I've discovered while working on this ticket.
First, on systems where Ornatrix plugin is not installed we are getting error messages in logs about it during the export. This happens because mel catch(…) command still logs error in script editor. I replaced it with catchQuiet that doesn't have such behavior.
Second, while working on the ticket I noticed the problem with incorrect check in instances loading and I fixed this one too.