### PR TITLE
Dmotor/fix missing lights instances

### DIFF
--- a/FireRender.Maya.Src/Context/FireRenderContext.cpp
+++ b/FireRender.Maya.Src/Context/FireRenderContext.cpp
@@ -2072,10 +2072,6 @@ bool FireRenderContext::AddSceneObject(const MDagPath& dagPath)
 		{
 			ob = CreateSceneObject<FireRenderMesh, NodeCachingOptions::AddPath>(dagPath);
 		}
-		else if (isTransformWithInstancedShape(node, dagPathTmp))
-		{
-			ob = CreateSceneObject<FireRenderMesh, NodeCachingOptions::DontAddPath>(dagPathTmp);
-		}
 		else if (dagNode.typeId() == TypeId::FireRenderIESLightLocator
 			|| isLight(node)
 			|| VRay::isNonEnvironmentLight(dagNode))
@@ -2133,6 +2129,10 @@ bool FireRenderContext::AddSceneObject(const MDagPath& dagPath)
 		else if (dagNode.typeName() == "HairShape" && hairSupported)
 		{
 			ob = CreateSceneObject<FireRenderHairOrnatrix, NodeCachingOptions::AddPath>(dagPath);
+		}
+		else if (isTransformWithInstancedShape(node, dagPathTmp))
+		{
+			ob = CreateSceneObject<FireRenderMesh, NodeCachingOptions::DontAddPath>(dagPathTmp);
 		}
 		else if (dagNode.typeName() == "transform")
 		{


### PR DESCRIPTION
PURPOSE: Currently if instances of lights or other non-geometry objects are created than such objects are not exported into the scene.

EFFECT FOR THE USER: instanced lights are working correctly.

TECHINCAL DETAILS: My previous fix exposed bug that made instances of non-geometry objects to be not exported into the scene. This happened because of mistake in scene creation code.