### PR TITLE
Fix RPR Export Camerra Selection

### DIFF
--- a/FireRender.Maya.Src/FireRenderExportCmd.cpp
+++ b/FireRender.Maya.Src/FireRenderExportCmd.cpp
@@ -191,7 +191,7 @@ MStatus FireRenderExportCmd::doIt(const MArgList & args)
 				{
 					MDagPath& cameraPath = cameras[selectedCameraIdx];
 					MString cameraName = getNameByDagPath(cameraPath);
-					if (std::string(selectedCameraName.asChar()).find(std::string(cameraName.asChar())) != std::string::npos)
+					if (selectedCameraName == cameraName)
 					{
 						context.setCamera(cameras[selectedCameraIdx], true);
 						break;


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2164

PURPOSE: Currently RPR Export not always export scene with correct camera.

EFFECT FOR THE USER:  Have correct camera exported.

TECHINCAL DETAILS: Mistake in logic.