### PR TITLE
Enabling IPR for rpr 2.0

### DIFF
--- a/FireRender.Maya.Src/Context/TahoeContext.cpp
+++ b/FireRender.Maya.Src/Context/TahoeContext.cpp
@@ -421,3 +421,8 @@ bool TahoeContext::IsVolumeSupported() const
 {
 	return m_PluginVersion == TahoePluginVersion::RPR1;
 }
+
+bool TahoeContext::IsGLInteropEnabled() const
+{
+	return m_PluginVersion == TahoePluginVersion::RPR1;
+}

--- a/FireRender.Maya.Src/Context/TahoeContext.h
+++ b/FireRender.Maya.Src/Context/TahoeContext.h
@@ -41,6 +41,8 @@ protected:
 
 	bool needResolve() const override;
 
+	bool IsGLInteropEnabled() const;
+
 private:
 	TahoePluginVersion m_PluginVersion;
 

--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -2128,6 +2128,13 @@ TahoePluginVersion GetTahoeVersionToUse()
 
 bool CheckIsInteractivePossible()
 {
+	std::string result = std::getenv("RPR_RPR2_IPR_BACKDOOR");
+
+	if (result == "1")
+	{
+		return true;
+	}
+
 	return (GetTahoeVersionToUse() != TahoePluginVersion::RPR2 ||
 		GetRenderQualityForRenderType(RenderType::IPR) != RenderQuality::RenderQualityFull);
 }

--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -2128,11 +2128,14 @@ TahoePluginVersion GetTahoeVersionToUse()
 
 bool CheckIsInteractivePossible()
 {
-	std::string result = std::getenv("RPR_RPR2_IPR_BACKDOOR");
+	char* chStr = std::getenv("RPR_RPR2_IPR_BACKDOOR");
 
-	if (result == "1")
+	if (chStr != nullptr)
 	{
-		return true;
+		if (std::string(chStr) == "1")
+		{
+			return true;
+		}
 	}
 
 	return (GetTahoeVersionToUse() != TahoePluginVersion::RPR2 ||

--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -2128,17 +2128,7 @@ TahoePluginVersion GetTahoeVersionToUse()
 
 bool CheckIsInteractivePossible()
 {
-	char* chStr = std::getenv("RPR_RPR2_IPR_BACKDOOR");
-
-	if (chStr != nullptr)
-	{
-		if (std::string(chStr) == "1")
-		{
-			return true;
-		}
-	}
-
-	return (GetTahoeVersionToUse() != TahoePluginVersion::RPR2 ||
-		GetRenderQualityForRenderType(RenderType::IPR) != RenderQuality::RenderQualityFull);
+	// return treu in anticipation that IPR For RPR2 would be fixed for the next Release.
+	return true;
 }
 


### PR DESCRIPTION
PURPOSE:
Tahoe team can't enable IPR for RPR2 for testing

EFFECT OF CHANGES:
Tahoe team is able to enable IPR for RPR2 for testing

Also, We disabled Interop for RPR2 as unsupported