### PR TITLE
Dev/vgolovko/gltf file node change for hybrid

### DIFF
--- a/FireRender.Maya.Src/Context/FireRenderContext.cpp
+++ b/FireRender.Maya.Src/Context/FireRenderContext.cpp
@@ -115,7 +115,8 @@ FireRenderContext::FireRenderContext() :
 	m_backgroundTransparency(0),
 	m_shadowWeight(1),
 	m_bgWeight(1),
-	m_RenderType(RenderType::Undefined)
+	m_RenderType(RenderType::Undefined),
+	m_bIsGLTFExport(false)
 {
 	DebugPrint("FireRenderContext::FireRenderContext()");
 

--- a/FireRender.Maya.Src/Context/FireRenderContext.h
+++ b/FireRender.Maya.Src/Context/FireRenderContext.h
@@ -589,6 +589,9 @@ public:
 	virtual bool IsShaderNodeSupported(FireMaya::ShaderNode* shaderNode) const override { return true; }
 	virtual frw::Shader GetDefaultColorShader(frw::Value color) override;
 
+	bool IsGLTFExport() const override { return m_bIsGLTFExport; }
+	void SetGLTFExport(bool isGLTFExport) { m_bIsGLTFExport = isGLTFExport; }
+
 protected:
 	static int INCORRECT_PLUGIN_ID;
 
@@ -745,6 +748,8 @@ private:
 
 	// buffer to dump data from frame buffers, if needed
 	AOVPixelBuffers m_pixelBuffers;
+
+	bool m_bIsGLTFExport;
 
 public:
 	FireRenderEnvLight *iblLight = nullptr;

--- a/FireRender.Maya.Src/Context/FireRenderContextIFace.h
+++ b/FireRender.Maya.Src/Context/FireRenderContextIFace.h
@@ -42,4 +42,6 @@ public:
 	virtual bool IsShaderNodeSupported(FireMaya::ShaderNode* shaderNode) const = 0;
 	
 	virtual frw::Shader GetDefaultColorShader(frw::Value color) = 0;
+
+	virtual bool IsGLTFExport() const = 0;
 };

--- a/FireRender.Maya.Src/GLTFTranslator.cpp
+++ b/FireRender.Maya.Src/GLTFTranslator.cpp
@@ -68,6 +68,7 @@ MStatus	GLTFTranslator::writer(const MFileObject& file,
 	m_progressBars->SetPreparingSceneText(true);
 
 	fireRenderContext->setCallbackCreationDisabled(true);
+	fireRenderContext->SetGLTFExport(true);
 	if (!fireRenderContext->buildScene(false, false, true, [this](int progress) { m_progressBars->update(progress); } ))
 		return MS::kFailure;
 

--- a/FireRender.Maya.Src/MayaStandardNodesSupport/FileNodeConverter.cpp
+++ b/FireRender.Maya.Src/MayaStandardNodesSupport/FileNodeConverter.cpp
@@ -53,19 +53,28 @@ frw::Value MayaStandardNodeConverters::FileNodeConverter::Convert() const
 	}
 	else if (m_params.outPlugName == FireMaya::MAYA_FILE_NODE_OUTPUT_ALPHA)
 	{
-		MPlug alphaIsLuminancePlug = m_params.shaderNode.findPlug("alphaIsLuminance");
-		bool alphaIsLuminance = alphaIsLuminancePlug.asBool();
-
-		bool shouldUseAlphaIsLuminance = alphaIsLuminance || !image.HasAlphaChannel();
-		if (shouldUseAlphaIsLuminance)
+		if (!m_params.scope.GetIContextInfo()->IsGLTFExport())
 		{
-			// Calculate alpha is luminance value
-			return m_params.scope.MaterialSystem().ValueConvertToLuminance(imageNode);
+			MPlug alphaIsLuminancePlug = m_params.shaderNode.findPlug("alphaIsLuminance");
+			bool alphaIsLuminance = alphaIsLuminancePlug.asBool();
+
+			bool shouldUseAlphaIsLuminance = alphaIsLuminance || !image.HasAlphaChannel();
+			if (shouldUseAlphaIsLuminance)
+			{
+				// Calculate alpha is luminance value
+				return m_params.scope.MaterialSystem().ValueConvertToLuminance(imageNode);
+			}
+			else
+			{
+				// Select the real alpha value
+				return frw::Value(imageNode).SelectW();
+			}
 		}
+		// In GLTF Export case we don't process outAlpha as in rendering mode because in this case Arithmetic nodes will be produced 
+		// but Hybrid engine doesn't support them
 		else
 		{
-			// Select the real alpha value
-			return frw::Value(imageNode).SelectW();
+			return imageNode;
 		}
 	}
 


### PR DESCRIPTION
PURPOSE:
GLTF export output has Arithmetics in case of ususal FileNode processing

EFFECT OF CHANGE
GLTF export output does not have Arithmetics in case of ususal FileNode processing

Its done since Hybrid engine does not support Arithemtics