### PR TITLE
Backdoor for AOVs enabling in Interactive modes

### DIFF
--- a/FireRender.Maya.Src/Context/FireRenderContext.cpp
+++ b/FireRender.Maya.Src/Context/FireRenderContext.cpp
@@ -302,6 +302,12 @@ bool FireRenderContext::buildScene(bool isViewport, bool glViewport, bool freshe
 
 	m_globals.readFromCurrentScene();
 
+	// Backdoor for enabling aovs in IPR/Viewport
+	if (isInteractive())
+	{
+		EnableAOVsFromRSIfEnvVarSet(*this, m_globals.aovs);
+	}
+
 	if (m_globals.denoiserSettings.enabled)
 	{
 		turnOnAOVsForDenoiser();

--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -2132,3 +2132,15 @@ bool CheckIsInteractivePossible()
 		GetRenderQualityForRenderType(RenderType::IPR) != RenderQuality::RenderQualityFull);
 }
 
+// Backdoor to enable different AOVs from Render Settings in IPR and Viewport
+void EnableAOVsFromRSIfEnvVarSet(FireRenderContext& context, FireRenderAOVs& aovs)
+{
+	char* result = std::getenv("ENABLE_ADD_AOVS_FOR_INTERACTIVE");
+
+	if (result == nullptr || std::string(result) != "1")
+	{
+		return;
+	}
+
+	aovs.applyToContext(context);
+}

--- a/FireRender.Maya.Src/FireRenderUtils.h
+++ b/FireRender.Maya.Src/FireRenderUtils.h
@@ -1032,3 +1032,6 @@ std::vector<T> splitString(const T& s, typename T::traits_type::char_type delim)
 
 	return elems;
 }
+
+// Backdoor to enable different AOVs from Render Settings in IPR and Viewport
+void EnableAOVsFromRSIfEnvVarSet(FireRenderContext& context, FireRenderAOVs& aovs);


### PR DESCRIPTION
TICKET: RPRMAYA-2186

PURPOSE:
Tahoe team cannot get different AOV's enabled in interactinve rendering modes

EFFECT OF CHANGES:
Tahoe team is able to turn on AOVs in interactive using backdoor's environment variable