### PR TITLE
Gltf export aspect ratio fix

### DIFF
--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -1395,6 +1395,27 @@ MDagPathArray GetSceneCameras(bool renderableOnly /*= false*/)
 	return cameras;
 }
 
+void GetResolutionFromCommonTab(unsigned int& width, unsigned int& height)
+{
+	MObject defaultResolutionObject;
+	MSelectionList slist;
+	slist.add("defaultResolution");
+	slist.getDependNode(0, defaultResolutionObject);
+
+	MFnDependencyNode globalsNode(defaultResolutionObject);
+	MPlug plug = globalsNode.findPlug("width");
+	if (!plug.isNull())
+	{
+		width = plug.asInt();
+	}
+
+	plug = globalsNode.findPlug("height");
+	if (!plug.isNull())
+	{
+		height = plug.asInt();
+	}
+}
+
 MStatus GetDefaultRenderGlobals(MObject& outGlobalsNode)
 {
 	MSelectionList slist;

--- a/FireRender.Maya.Src/FireRenderUtils.h
+++ b/FireRender.Maya.Src/FireRenderUtils.h
@@ -398,6 +398,9 @@ MPlug GetRadeonProRenderGlobalsPlug(const char* name, MStatus* status = nullptr)
 // Is IBL image fliping switched on
 bool IsFlipIBL();
 
+// Get Render Size from Common Tab
+void GetResolutionFromCommonTab(unsigned int& width, unsigned int& height);
+
 class HardwareResources
 {
 	HardwareResources();

--- a/FireRender.Maya.Src/GLTFTranslator.cpp
+++ b/FireRender.Maya.Src/GLTFTranslator.cpp
@@ -73,8 +73,13 @@ MStatus	GLTFTranslator::writer(const MFileObject& file,
 		return MS::kFailure;
 
 	// Some resolution should be set. It's requred to retrieve background image.
-	// We set 800x600 here but we can set any other resolution.
-	fireRenderContext->setResolution(800, 600, false, 0);
+	FireRenderGlobalsData renderData;
+	
+	unsigned int width = 800;	// use some defaults
+	unsigned int height = 600;
+	GetResolutionFromCommonTab(width, height);
+
+	fireRenderContext->setResolution(width, height, true, 0);
 	fireRenderContext->ConsiderSetupDenoiser();
 
 	MStatus status;


### PR DESCRIPTION
TICKET: RPRMAYA-2185

PURPOSE:
Camera sensor size gets exported incorrectly in GLTF in some scenarios

EFFECT OF CHANGES:
Camera sensor size gets exported correctly in GLTF 