### PR TITLE
Runtime aov switch in IPR

### DIFF
--- a/FireRender.Maya.Src/FireRenderAOVs.cpp
+++ b/FireRender.Maya.Src/FireRenderAOVs.cpp
@@ -382,6 +382,19 @@ int FireRenderAOVs::getNumberOfAOVs()
 	return (int)m_aovs.size();
 }
 
+bool FireRenderAOVs::IsAOVActive(unsigned int aov) const
+{
+	auto it = m_aovs.find(aov);
+
+	if (it == m_aovs.end())
+	{
+		assert(false);
+		return false;
+	}
+
+	return it->second->active;
+}
+
 MString FireRenderAOVs::GetEXRCompressionType() const 
 { 
 	return m_exrCompressionType; 

--- a/FireRender.Maya.Src/FireRenderAOVs.h
+++ b/FireRender.Maya.Src/FireRenderAOVs.h
@@ -87,6 +87,8 @@ public:
 	/** Gets number of AOVs */
 	int getNumberOfAOVs();
 
+	bool IsAOVActive(unsigned int aov) const;
+
 	MString GetEXRCompressionType() const;
 	TypeDesc::BASETYPE GetChannelFormat() const;
 

--- a/FireRender.Maya.Src/FireRenderIpr.cpp
+++ b/FireRender.Maya.Src/FireRenderIpr.cpp
@@ -607,6 +607,7 @@ void FireRenderIpr::globalsChangedCallback(MNodeMessage::AttributeMessage msg, M
 
 bool FireRenderIpr::ShouldOldAOVBeDisabled(int aov)
 {
+	// We need to keep enabled both of these AOV because of Core restrictmenets. VARIANCE is used for adaptive sampling
 	if (m_currentAOVToDisplay == RPR_AOV_COLOR ||
 		m_currentAOVToDisplay == RPR_AOV_VARIANCE)
 	{

--- a/FireRender.Maya.Src/FireRenderIpr.cpp
+++ b/FireRender.Maya.Src/FireRenderIpr.cpp
@@ -144,6 +144,10 @@ bool FireRenderIpr::start()
 	MStatus status = MGlobal::getActiveSelectionList(m_previousSelectionList);
 	CHECK_MSTATUS(status);
 
+	MObject radeonProRenderGlobalsNode;
+	GetRadeonProRenderGlobals(radeonProRenderGlobalsNode);
+	m_renderGlobalsCallback = MNodeMessage::addAttributeChangedCallback(radeonProRenderGlobalsNode, FireRenderIpr::globalsChangedCallback, this, &status);
+
 	auto ret = FireRenderThread::RunOnceAndWait<bool>([this, &showWarningDialog]()
 	{
 		// Stop before restarting if already running.
@@ -286,6 +290,12 @@ bool FireRenderIpr::stop()
 			FireRenderThread::RunItemsQueuedForTheMainThread();
 			this_thread::sleep_for(1ms);
 		}
+	}
+
+	if (m_renderGlobalsCallback)
+	{
+		MMessage::removeCallback(m_renderGlobalsCallback);
+		m_renderGlobalsCallback = 0;
 	}
 
 	return true;
@@ -565,4 +575,48 @@ void FireRenderIpr::refreshContext()
 		AutoMutexLock contextLock(m_contextLock);
 		m_contextPtr->Freshen(false);
 	});
+}
+
+void FireRenderIpr::SwitchCurrentAOVToBeDisplayed(int newAOV)
+{
+	AutoMutexLock contextLock(m_contextLock);
+
+	if (ShouldOldAOVBeDisabled(m_currentAOVToDisplay))
+	{
+		m_contextPtr->enableAOVAndReset(m_currentAOVToDisplay, false, nullptr);
+	}
+
+	m_currentAOVToDisplay = newAOV;
+	m_contextPtr->enableAOVAndReset(m_currentAOVToDisplay, true, nullptr);
+}
+
+void FireRenderIpr::globalsChangedCallback(MNodeMessage::AttributeMessage msg, MPlug &plug, MPlug &otherPlug, void *clientData)
+{
+	MString name = plug.name();
+
+	if ( (name != "RadeonProRenderGlobals.aovDisplayedInRenderView") ||
+		!(msg | MNodeMessage::AttributeMessage::kAttributeSet))
+	{
+		return;
+	}
+
+	FireRenderIpr*  thisObject = reinterpret_cast<FireRenderIpr*> (clientData);
+
+	thisObject->SwitchCurrentAOVToBeDisplayed(plug.asInt());
+}
+
+bool FireRenderIpr::ShouldOldAOVBeDisabled(int aov)
+{
+	if (m_currentAOVToDisplay == RPR_AOV_COLOR ||
+		m_currentAOVToDisplay == RPR_AOV_VARIANCE)
+	{
+		return false;
+	}
+
+	MObject radeonProRenderGlobalsNode;
+	GetRadeonProRenderGlobals(radeonProRenderGlobalsNode);
+
+	FireRenderAOVs aovs;
+	aovs.readFromGlobals(MFnDependencyNode(radeonProRenderGlobalsNode));
+	return !aovs.IsAOVActive(aov);
 }

--- a/FireRender.Maya.Src/FireRenderIpr.h
+++ b/FireRender.Maya.Src/FireRenderIpr.h
@@ -111,6 +111,12 @@ private:
 	/** Updates Render information at the bottom of Maya's render view */
 	void updateMayaRenderInfo();
 
+	void SwitchCurrentAOVToBeDisplayed(int newAOV);
+	bool ShouldOldAOVBeDisabled(int aov);
+
+	// Called when an attribute on the FireRenderGlobals node change
+	static void globalsChangedCallback(MNodeMessage::AttributeMessage msg, MPlug &plug, MPlug &otherPlug, void *clientData);
+
 private:
 
 	// Members
@@ -169,4 +175,6 @@ private:
 	std::mutex m_regionUpdateMutex;
 
 	MSelectionList m_previousSelectionList;
+
+	MCallbackId m_renderGlobalsCallback = 0;
 };


### PR DESCRIPTION
TICKET: RPRMAYA-778

PURPOSE:
User cannot change current AOV in IPR without restart

EFFECT OF CHANGES:
User is now able to change current AOV in IPR without restart.