### PR TITLE
RPRMAYA-2709 Fix wrong AOV output in IPR when denosier is enabled

### DIFF
--- a/FireRender.Maya.Src/FireRenderIpr.cpp
+++ b/FireRender.Maya.Src/FireRenderIpr.cpp
@@ -395,7 +395,8 @@ bool FireRenderIpr::RunOnViewportThread()
 				m_finishedFrame = true;
 
 				// run denoiser
-				if (m_contextPtr->IsDenoiserEnabled())
+				bool isOutputAOVColor = m_currentAOVToDisplay == RPR_AOV_COLOR;
+				if (m_contextPtr->IsDenoiserEnabled() && isOutputAOVColor)
 				{
 					std::vector<float> vecData = m_contextPtr->DenoiseIntoRAM();
 					assert(vecData.size() != 0);


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2709

PURPOSE: Currently in IPR mode if denoiser is enabled and after ipr finishes rendering Color AOV will be displayed in render view even if other AOV was selected.

EFFECT FOR THE USER: Selected AOV always displayed in render view