### PR TITLE
RPRMAYA-2726 Add extra visibility flag to hairs

### DIFF
--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -1501,6 +1501,17 @@ namespace frw
 			{
 				checkStatus(res);
 			}
+
+			res = rprCurveSetVisibilityFlag(Handle(), RPR_CURVE_VISIBILITY_DIFFUSE, visible);
+
+			if (res == RPR_ERROR_UNSUPPORTED)
+			{
+				return;
+			}
+			else
+			{
+				checkStatus(res);
+			}
 		}
 
 		void SetReflectionVisibility(bool visible)


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2726

PURPOSE: Currently there are artifacts when scene is rendered with visibility of hairs disabled

EFFECT FOR USER: No artifacts

TECHNICAL DETAILS: Need to set extra visibility flag for hairs so there would be no artifacts when their visibility is disabled