### PR TITLE
RPRMAYA-2678 Add zero size mesh check

### DIFF
--- a/FireRender.Maya.Src/FireRenderObjects.cpp
+++ b/FireRender.Maya.Src/FireRenderObjects.cpp
@@ -1436,7 +1436,10 @@ void FireRenderMesh::SetupObjectId(MObject parentTransformObject)
 
 	for (FrElement element : m.elements)
 	{
-		element.shape.SetObjectId(objectId);
+		if (element.shape.Handle() != nullptr)
+		{
+			element.shape.SetObjectId(objectId);
+		}
 	}
 }
 

--- a/FireRender.Maya.Src/Translators/MeshTranslator.cpp
+++ b/FireRender.Maya.Src/Translators/MeshTranslator.cpp
@@ -64,6 +64,7 @@ bool FireMaya::MeshTranslator::MeshPolygonData::Initialize(const MFnMesh& fnMesh
 
 	countVertices = fnMesh.numVertices(&mstatus);
 	assert(MStatus::kSuccess == mstatus);
+	assert(countVertices > 0);
 
 	// pointer to array of normal coordinates in Maya
 	pNormals = fnMesh.getRawNormals(&mstatus);

--- a/FireRender.Maya.Src/Translators/MeshTranslator.cpp
+++ b/FireRender.Maya.Src/Translators/MeshTranslator.cpp
@@ -64,7 +64,10 @@ bool FireMaya::MeshTranslator::MeshPolygonData::Initialize(const MFnMesh& fnMesh
 
 	countVertices = fnMesh.numVertices(&mstatus);
 	assert(MStatus::kSuccess == mstatus);
-	assert(countVertices > 0);
+	if (countVertices == 0)
+	{
+		return false;
+	}
 
 	// pointer to array of normal coordinates in Maya
 	pNormals = fnMesh.getRawNormals(&mstatus);

--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -4147,6 +4147,12 @@ namespace frw
 		const rpr_int* tidx_stride, const rpr_int * num_face_vertices, size_t num_faces, std::string optionalMeshName) const
 	{
 		FRW_PRINT_DEBUG("CreateMesh() - %d faces\n", num_faces);
+		assert(num_vertices != 0);
+		assert(num_faces != 0);
+
+		if (num_vertices == 0 || num_faces == 0)
+			return Shape();
+
 		rpr_shape shape = nullptr;
 
 		auto status = rprContextCreateMeshEx(Handle(),


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2678

PURPOSE: Because of the bug with Bifrost plugin mesh with zero size yet valid flags can be sent to export. Trying to create such mesh causes RPR to crash down the line In this PR we add an extra check to prevent such case from happening.

EFFECT FOR THE USER: No crash related to Bifrost mesh happening