### PR TITLE
Fix subdivision parameter passed in RPR2 mode

### DIFF
--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -3951,7 +3951,7 @@ namespace frw
 			rpr_int res = rprShapeSetSubdivisionAutoRatioCap(Handle(), autoRatioCap);
 			checkStatusThrow(res, "Unable to set Adaptive Subdivision!");
 
-			res = rprShapeSetSubdivisionFactor(Handle(), calculatedFactor);
+			res = rprShapeSetSubdivisionFactor(Handle(), adaptiveFactor);
 			checkStatusThrow(res, "Unable to set Adaptive Subdivision!");
 		}
 	}


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-1145

PURPOSE: Currently adaptive subdivision is not working in RPR20 mode in Maya.

EFFECT FOR THE USER: Adaptive subdivision working in RPR20 mode in Maya.