### PR TITLE
 Add NHair visibility UI flags to RPR folder

### DIFF
--- a/FireRender.Maya.Src/scripts/setupFireRenderExtraUI.mel
+++ b/FireRender.Maya.Src/scripts/setupFireRenderExtraUI.mel
@@ -26,6 +26,15 @@ global proc fireRenderNodeTemplateCallback(string $nodeName)
 		editorTemplate -beginLayout "RPR" -collapse true;
 			editorTemplate -addControl "rprHairMaterial";
 			editorTemplate -addControl "castsShadows";
+			editorTemplate -addControl "visibleInReflections";
+			editorTemplate -addControl "visibleInRefractions";
+		editorTemplate -endLayout;
+	}
+
+	if ($nodeType == "pfxHair")
+	{
+		editorTemplate -beginLayout "RPR" -collapse true;
+			editorTemplate -addControl "primaryVisibility";
 		editorTemplate -endLayout;
 	}
 }


### PR DESCRIPTION
PURPOSE: Small UI change requested by Atsushi. Currently it is not convenient for the user to find NHair visibility flags in its UI.

EFFECT FOR THE USER: Visibility flags are now located in "RPR" folder. Note that these are the same flags that Maya have by default they are duplicated (and connected) with each other so both old way of setting their value and new one will work.