### PR TITLE
RPRMAYA-2258 Fix multiple reference missing geometry issue

### DIFF
--- a/FireRender.Maya.Src/FireRenderUtils.cpp
+++ b/FireRender.Maya.Src/FireRenderUtils.cpp
@@ -1040,7 +1040,7 @@ std::string getNodeUUid(const MDagPath& node)
 		{
 			// Referenced node name guaranteed to be unique by Maya. User can't change it's name because node is locked.
 			std::stringstream sstrm;
-			sstrm << id.c_str() << ":" << dagNode.name();
+			sstrm << id.c_str() << ":" << dagNode.fullPathName();
 			id = sstrm.str();
 		}
 	}


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2258

PURPOSE: Currently if there are multiple references to same file in one scene it could cause missing geometry

EFFECT FOR THE USER: References working as expected