### PR TITLE
RPRMAYA-2718 Mesh export optimization

### DIFF
--- a/FireRender.Maya.Src/Translators/SingleShaderMeshTranslator.h
+++ b/FireRender.Maya.Src/Translators/SingleShaderMeshTranslator.h
@@ -35,7 +35,8 @@ namespace FireMaya
 			std::vector<int>& normalIndices,
 			std::vector<std::vector<int>>& uvIndices,
 			std::vector<MColor>& vertexColors,
-			std::vector<int>& vertexIndices
+			std::vector<int>& vertexIndices,
+			std::vector<int>& numFaceVertices
 		);
 
 		static void FillIndicesUV(

--- a/FireRender.Maya.Src/Translators/SingleShaderMeshTranslator.h
+++ b/FireRender.Maya.Src/Translators/SingleShaderMeshTranslator.h
@@ -28,19 +28,38 @@ namespace FireMaya
 		);
 
 	private:
+		struct MeshIndicesData
+		{
+			std::vector<int>& triangleVertexIndices;
+			std::vector<int>& normalIndices;
+			std::vector<std::vector<int>>& uvIndices;
+			std::vector<MColor>& vertexColors;
+			std::vector<int>& colorVertexIndices;
+			std::vector<int>& numFaceVertices;
+
+			MeshIndicesData(
+				std::vector<int>& _triangleVertexIndices,
+				std::vector<int>& _normalIndices,
+				std::vector<std::vector<int>>& _uvIndices,
+				std::vector<MColor>& _vertexColors,
+				std::vector<int>& _colorVertexIndices,
+				std::vector<int>& _numFaceVertices)
+				: triangleVertexIndices(_triangleVertexIndices)
+				, normalIndices(_normalIndices)
+				, uvIndices(_uvIndices)
+				, vertexColors(_vertexColors)
+				, colorVertexIndices(_colorVertexIndices)
+				, numFaceVertices(_numFaceVertices)
+			{};
+		};
+
 		static void AddPolygonSingleShader(
-			MItMeshPolygon& it,
+			MItMeshPolygon& meshPolygonIterator,
 			const MStringArray& uvSetNames,
-			std::vector<int>& triangleVertexIndices,
-			std::vector<int>& normalIndices,
-			std::vector<std::vector<int>>& uvIndices,
-			std::vector<MColor>& vertexColors,
-			std::vector<int>& vertexIndices,
-			std::vector<int>& numFaceVertices
+			MeshIndicesData& idxData
 		);
 
 		static void FillIndicesUV(
-			const unsigned uvSetCount,
 			const MIntArray& vertexList,
 			const std::map<int, int>& vertexIdxGlobalToLocal,
 			const MStringArray& uvSetNames,
@@ -53,6 +72,15 @@ namespace FireMaya
 			const std::map<int, int>& vertexIdxGlobalToLocal,
 			MItMeshPolygon& meshPolygonIterator,
 			std::vector<int>& normalIndices
+		);
+
+		static void ProcessIndexesSimplified(
+			MItMeshPolygon& meshPolygonIterator,
+			const MStringArray& uvSetNames,
+			MeshIndicesData& idxData,
+			unsigned int localIdx,
+			MIntArray& vertices,
+			MColorArray& polygonColors
 		);
 
 	};


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-2718 (note: two more PR will be created for this ticket with other optimizations)

PURPOSE: For big meshes processing time is too slow. In this PR 2 optimizations were implemented:
- support of export of quads instead of triangle when possible;
- simplified export of triangles when possible;

EFFECT FOR THE USER: Faster scene synchronization time

NOTE FOR REVIEWERS: Optimizations were implemented only for SingleShaderMeshTranslator. This is done on purpose because MultipleShaderMeshTranslator will be retired as we have implemented per face material support (will have this PR soon)