### PR TITLE
Add RPR visibility flags to NHair

### DIFF
--- a/FireRender.Maya.Src/FireRenderHairs.cpp
+++ b/FireRender.Maya.Src/FireRenderHairs.cpp
@@ -1153,8 +1153,6 @@ void FireRenderHairNHair::setRenderStats(MDagPath dagPath)
 	MPlug visibleInReflectionsPlug = depNode.findPlug("nhairVisibleInReflections");
 	if (!visibleInReflectionsPlug.isNull())
 	{
-		MString dbgName = visibleInReflectionsPlug.name();
-
 		bool visibleInReflections = false;
 		visibleInReflectionsPlug.getValue(visibleInReflections);
 		setReflectionVisibility(visibleInReflections);

--- a/FireRender.Maya.Src/FireRenderHairs.cpp
+++ b/FireRender.Maya.Src/FireRenderHairs.cpp
@@ -1127,10 +1127,7 @@ void FireRenderHairNHair::setRenderStats(MDagPath dagPath)
 	if (!dagPath.isValid())
 		return;
 
-	// in nhair we have to check different nodes for plug value
-	SetHairPrimaryVisibility(this, dagPath);
-
-	// for the rest of the flags we check pfxHairShape object
+	// in nhair we have to check pfxHairShape object
 	MObject hairObject = dagPath.node();
 
 	// get hairSystemShape object from pfxHairShape object
@@ -1143,7 +1140,41 @@ void FireRenderHairNHair::setRenderStats(MDagPath dagPath)
 	MStatus status = dagHairSystemShapeObj.getPath(hairSystemShapePath);
 	assert(status == MStatus::kSuccess);
 
-	FireRenderHair::setRenderStats(hairSystemShapePath);
+	MFnDependencyNode depNode(hairSystemShapePath.node());
+
+	MPlug primaryVisibilityPlug = depNode.findPlug("nhairIsVisible");
+	if (!primaryVisibilityPlug.isNull())
+	{
+		bool primaryVisibility = true;
+		primaryVisibilityPlug.getValue(primaryVisibility);
+		setPrimaryVisibility(primaryVisibility);
+	}
+
+	MPlug visibleInReflectionsPlug = depNode.findPlug("nhairVisibleInReflections");
+	if (!visibleInReflectionsPlug.isNull())
+	{
+		MString dbgName = visibleInReflectionsPlug.name();
+
+		bool visibleInReflections = false;
+		visibleInReflectionsPlug.getValue(visibleInReflections);
+		setReflectionVisibility(visibleInReflections);
+	}
+
+	MPlug visibleInRefractionsPlug = depNode.findPlug("nhairVisibleInRefractions");
+	if (!visibleInRefractionsPlug.isNull())
+	{
+		bool visibleInRefractions = false;
+		visibleInRefractionsPlug.getValue(visibleInRefractions);
+		setRefractionVisibility(visibleInRefractions);
+	}
+
+	MPlug castsShadowsPlug = depNode.findPlug("castsShadows");
+	if (!castsShadowsPlug.isNull())
+	{
+		bool castsShadows = false;
+		castsShadowsPlug.getValue(castsShadows);
+		setCastShadows(castsShadows);
+	}
 }
 
 

--- a/FireRender.Maya.Src/pluginMain.cpp
+++ b/FireRender.Maya.Src/pluginMain.cpp
@@ -475,6 +475,18 @@ void AddExtensionAttributesCommon()
 	nAttr.setNiceNameOverride("Hair Casts Shadows");
 	status = hairSystemClass.addExtensionAttribute(hairCastShadows);
 
+	MObject nhairVisible = nAttr.create("nhairIsVisible", "nhvi", MFnNumericData::kBoolean, true, &status);
+	nAttr.setNiceNameOverride("Is Visible");
+	status = hairSystemClass.addExtensionAttribute(nhairVisible);
+
+	MObject nhairVisibleInReflections = nAttr.create("nhairVisibleInReflections", "nhrf", MFnNumericData::kBoolean, true, &status);
+	nAttr.setNiceNameOverride("Visible In Reflections");
+	status = hairSystemClass.addExtensionAttribute(nhairVisibleInReflections);
+
+	MObject nhairVisibleInRefractions = nAttr.create("nhairVisibleInRefractions", "nhrr", MFnNumericData::kBoolean, true, &status);
+	nAttr.setNiceNameOverride("Visible In Refractions");
+	status = hairSystemClass.addExtensionAttribute(nhairVisibleInRefractions);
+
 	// Adding RPRObjectId to all transforms
 	MObject objectIdAttr = nAttr.create("RPRObjectId", "roi", MFnNumericData::kLong, 0);
 

--- a/FireRender.Maya.Src/scripts/setupFireRenderExtraUI.mel
+++ b/FireRender.Maya.Src/scripts/setupFireRenderExtraUI.mel
@@ -24,17 +24,11 @@ global proc fireRenderNodeTemplateCallback(string $nodeName)
 	if ($nodeType == "hairSystem")
 	{
 		editorTemplate -beginLayout "RPR" -collapse true;
+			editorTemplate -addControl "nhairIsVisible";
 			editorTemplate -addControl "rprHairMaterial";
 			editorTemplate -addControl "castsShadows";
-			editorTemplate -addControl "visibleInReflections";
-			editorTemplate -addControl "visibleInRefractions";
-		editorTemplate -endLayout;
-	}
-
-	if ($nodeType == "pfxHair")
-	{
-		editorTemplate -beginLayout "RPR" -collapse true;
-			editorTemplate -addControl "primaryVisibility";
+			editorTemplate -addControl "nhairVisibleInReflections";
+			editorTemplate -addControl "nhairVisibleInRefractions";
 		editorTemplate -endLayout;
 	}
 }


### PR DESCRIPTION
PURPOSE: By default Maya native NHair visibilty flags for "visible in reflections" and "visible in refractions" are false and this can not be overriden. Also there two flags and general visibility flags are in different objects. In this PR new flags are introduced. 
This cahnge is requested by Atsushi.

EFFECT FOR THE USER: 3 new flags will appear in "RPR" folder of NHair node where users will be able to uncheck/check them. These flags will be used in visibility logic. Maya native NHair visibility flags will be ignored by the plugin.