### PR TITLE
IES light rotation fix

### DIFF
--- a/FireRender.Maya.Src/Lights/IES/FireRenderIESLight.cpp
+++ b/FireRender.Maya.Src/Lights/IES/FireRenderIESLight.cpp
@@ -32,7 +32,6 @@ limitations under the License.
 
 MObject FireRenderIESLightLocator::aFilePath;
 MObject FireRenderIESLightLocator::aAreaWidth;
-MObject FireRenderIESLightLocator::aRotations[3];
 MObject	FireRenderIESLightLocator::aIntensity;
 MObject	FireRenderIESLightLocator::aDisplay;
 MObject FireRenderIESLightLocator::aMeshRepresentationUpdated;
@@ -95,29 +94,6 @@ MStatus FireRenderIESLightLocator::initialize()
 	nAttr.setSoftMax(2.0);
 	addAttribute(aAreaWidth);
 
-	const char* aRotationFullNames[3]
-	{
-		"xRotation",
-		"yRotation",
-		"zRotation",
-	};
-
-	const char* aRotationShortNames[3]
-	{
-		"rtx",
-		"rty",
-		"rtz",
-	};
-
-	for (size_t i = 0; i < 3; ++i)
-	{
-		aRotations[i] = nAttr.create(aRotationFullNames[i], aRotationShortNames[i], MFnNumericData::kFloat, 0.f);
-		makeAttribute(nAttr);
-		nAttr.setSoftMin(-180);
-		nAttr.setSoftMax( 180);
-		addAttribute(aRotations[i]);
-	}
-
 	aIntensity = nAttr.create("intensity", "i", MFnNumericData::kFloat, 1.f);
 	makeAttribute(nAttr);
 	nAttr.setMin(0);
@@ -145,9 +121,7 @@ MStatus FireRenderIESLightLocator::initialize()
 		};
 	};
 
-	setMeshReprAffects(
-		aFilePath, aDisplay, aAreaWidth,
-		aRotations[0], aRotations[1], aRotations[2]);
+	setMeshReprAffects(aFilePath, aDisplay, aAreaWidth);
 
 	return MS::kSuccess;
 }
@@ -167,31 +141,6 @@ bool FireRenderIESLightLocator::GetDisplay() const
 	return findPlugTryGetValue(thisMObject(), aDisplay, true);
 }
 
-float FireRenderIESLightLocator::GetXRotation() const
-{
-	return GetAxisRotation(0);
-}
-
-float FireRenderIESLightLocator::GetYRotation() const
-{
-	return GetAxisRotation(1);
-}
-
-float FireRenderIESLightLocator::GetZRotation() const
-{
-	return GetAxisRotation(2);
-}
-
-float FireRenderIESLightLocator::GetAxisRotation(unsigned axis) const
-{
-	if (axis > 2)
-	{
-		assert(!"Invalid usage");
-		return 0.f;
-	}
-
-	return findPlugTryGetValue(thisMObject(), FireRenderIESLightLocator::aRotations[axis], 0.f);
-}
 
 void FireRenderIESLightLocator::UpdateMesh(bool forced) const
 {
@@ -200,12 +149,6 @@ void FireRenderIESLightLocator::UpdateMesh(bool forced) const
 		m_mesh->SetEnabled(GetDisplay());
 		m_mesh->SetScale(GetAreaWidth());
 		m_mesh->SetFilename(GetFilename(), forced);
-
-		for (int axis = 0; axis < 3; ++axis)
-		{
-			float angle = GetAxisRotation(axis);
-			m_mesh->SetAngle(angle, axis);
-		}
 	}
 }
 
@@ -324,9 +267,9 @@ void FireRenderIESLightLocatorOverride::updateRenderItems(const MDagPath& path, 
 		float areaWidth = GetAreaWidth();
 
 		MEulerRotation rotation(
-			FireMaya::deg2rad(GetAxisRotation(0)),
-			FireMaya::deg2rad(GetAxisRotation(1)),
-			FireMaya::deg2rad(GetAxisRotation(2)));
+			FireMaya::deg2rad(0.f),
+			FireMaya::deg2rad(0.f),
+			FireMaya::deg2rad(0.f));
 		MMatrix matrix = rotation.asMatrix();
 
 		MTransformationMatrix trm;
@@ -408,30 +351,4 @@ float FireRenderIESLightLocatorOverride::GetAreaWidth() const
 bool FireRenderIESLightLocatorOverride::GetDisplay() const
 {
 	return findPlugTryGetValue(m_obj, FireRenderIESLightLocator::aDisplay, true);
-}
-
-float FireRenderIESLightLocatorOverride::GetXRotation() const
-{
-	return GetAxisRotation(0);
-}
-
-float FireRenderIESLightLocatorOverride::GetYRotation() const
-{
-	return GetAxisRotation(1);
-}
-
-float FireRenderIESLightLocatorOverride::GetZRotation() const
-{
-	return GetAxisRotation(2);
-}
-
-float FireRenderIESLightLocatorOverride::GetAxisRotation(unsigned axis) const
-{
-	if (axis > 2)
-	{
-		assert(!"Invalid usage");
-		return 0.f;
-	}
-
-	return findPlugTryGetValue(m_obj, FireRenderIESLightLocator::aRotations[axis], 0.f);
 }

--- a/FireRender.Maya.Src/Lights/IES/FireRenderIESLight.cpp
+++ b/FireRender.Maya.Src/Lights/IES/FireRenderIESLight.cpp
@@ -266,10 +266,7 @@ void FireRenderIESLightLocatorOverride::updateRenderItems(const MDagPath& path, 
 	{
 		float areaWidth = GetAreaWidth();
 
-		MEulerRotation rotation(
-			FireMaya::deg2rad(0.f),
-			FireMaya::deg2rad(0.f),
-			FireMaya::deg2rad(0.f));
+		MEulerRotation rotation(M_PI / 2, 0, 0);
 		MMatrix matrix = rotation.asMatrix();
 
 		MTransformationMatrix trm;

--- a/FireRender.Maya.Src/Lights/IES/FireRenderIESLight.h
+++ b/FireRender.Maya.Src/Lights/IES/FireRenderIESLight.h
@@ -66,10 +66,6 @@ public:
 	MString GetFilename() const;
 	float GetAreaWidth() const;
 	bool GetDisplay() const;
-	float GetXRotation() const;
-	float GetYRotation() const;
-	float GetZRotation() const;
-	float GetAxisRotation(unsigned axis) const;
 
 public:
 	static MTypeId	id;
@@ -78,7 +74,6 @@ public:
 	static MString	drawRegistrantId;
 	static MObject	aFilePath;
 	static MObject	aAreaWidth;
-	static MObject	aRotations[3];
 	static MObject	aIntensity;
 	static MObject	aDisplay;
 	static MObject	aMeshRepresentationUpdated;
@@ -134,10 +129,6 @@ public:
 
 	float GetAreaWidth() const;
 	bool GetDisplay() const;
-	float GetXRotation() const;
-	float GetYRotation() const;
-	float GetZRotation() const;
-	float GetAxisRotation(unsigned axis) const;
 
 private:
 

--- a/FireRender.Maya.Src/VRay.cpp
+++ b/FireRender.Maya.Src/VRay.cpp
@@ -382,9 +382,7 @@ namespace FireMaya
 				status = dagNode.getPath(dagPath);
 				assert(status == MStatus::kSuccess);
 
-				MEulerRotation rotation(- M_PI / 2,	0, 0);
-				ret.matrix = rotation.asMatrix();
-				ret.matrix *= dagPath.inclusiveMatrix(&status);
+				ret.matrix = dagPath.inclusiveMatrix(&status);
 			}
 
 			ret.filePath = findPlugTryGetValue(depNodeVRayLight, "iesFile", ""_ms);

--- a/FireRender.Maya.Src/VRay.cpp
+++ b/FireRender.Maya.Src/VRay.cpp
@@ -382,15 +382,7 @@ namespace FireMaya
 				status = dagNode.getPath(dagPath);
 				assert(status == MStatus::kSuccess);
 
-				auto getRotation = [&](const char* name)
-				{
-					return FireMaya::deg2rad(findPlugTryGetValue(depNodeVRayLight, name, 0.0f));
-				};
-
-				MEulerRotation rotation(
-					getRotation("xRotation") - M_PI / 2,
-					getRotation("yRotation"),
-					getRotation("zRotation"));
+				MEulerRotation rotation(- M_PI / 2,	0, 0);
 				ret.matrix = rotation.asMatrix();
 				ret.matrix *= dagPath.inclusiveMatrix(&status);
 			}

--- a/FireRender.Maya.Src/scripts/AERPRIESTemplate.mel
+++ b/FireRender.Maya.Src/scripts/AERPRIESTemplate.mel
@@ -76,9 +76,6 @@ global proc AERPRIESTemplate( string $nodeName )
 		editorTemplate -beginLayout "Radeon ProRender" -collapse 0;
 			editorTemplate -callCustom AEIESFileNameNew AEIESFileNameReplace "iesFile";
 			editorTemplate -addControl "areaWidth";
-			editorTemplate -addControl "xRotation";
-			editorTemplate -addControl "yRotation";
-			editorTemplate -addControl "zRotation";
 			editorTemplate -addControl "intensity";
 			editorTemplate -addControl "display";
 			editorTemplate -addControl "color";


### PR DESCRIPTION
JIRA TICKETS: RPRMAYA-1757, RPRMAYA-2559, RPRMAYA-2999

PURPOSE: 1) RPR IES light has unused rotation parameters
                 2) RPR IES light's default rotation not same with arnold
                 3) RPR IES light can't be moved without any issues
                 4) RPR IES light can produce incorrect export

EFFECT OF CHANGES: 1) Internal rotation parameters has been removed
                                    2) Now initial rotation is same with arnold
                                    3) Move and export issues has been fixed 