### PR TITLE
Ward node removing

### DIFF
--- a/FireRender.Maya.Src/FireMaya.cpp
+++ b/FireRender.Maya.Src/FireMaya.cpp
@@ -1704,7 +1704,7 @@ frw::Shader FireMaya::Scope::ParseShader(MObject node)
 			diffuseShader.SetColor(diffColor);
 
 			///
-			frw::Shader wardShader(materialSystem, frw::ShaderTypeWard);
+			frw::Shader specularShader(materialSystem, frw::ShaderTypeMicrofacetAnisotropicReflection);
 
 			frw::Value roughness = GetValue(shaderNode.findPlug("roughness"));
 			frw::Value fresnel = GetValue(shaderNode.findPlug("fresnelReflectiveIndex"));
@@ -1722,18 +1722,23 @@ frw::Shader FireMaya::Scope::ParseShader(MObject node)
 				mayaSpreadY = 98.0;
 			}
 
-			frw::Value spreadX = materialSystem.ValueMul(roughness, 1.0 - mayaSpreadX / 100.0);
-			frw::Value spreadY = materialSystem.ValueMul(roughness, 1.0 - mayaSpreadY / 100.0);
+			frw::Value roughnessX = materialSystem.ValueMul(roughness, 1.0 - mayaSpreadX / 100.0);
+			frw::Value roughnessY = materialSystem.ValueMul(roughness, 1.0 - mayaSpreadY / 100.0);
+			
+			frw::Value anisotropic = materialSystem.ValueSub(mayaSpreadY, mayaSpreadX);
+			anisotropic = materialSystem.ValueDiv(anisotropic, frw::Value(100.0));
+			specularShader.SetValue(RPR_MATERIAL_INPUT_ANISOTROPIC, anisotropic);
 
-			wardShader.SetValue(RPR_MATERIAL_INPUT_COLOR, specularColor);
+			specularShader.SetValue(RPR_MATERIAL_INPUT_ROUGHNESS, roughness);
+
+			specularShader.SetValue(RPR_MATERIAL_INPUT_COLOR, specularColor);
+
 			double rads = -1.0 * angle.GetX() * M_PI / 180.0;
 			frw::Value radians = frw::Value(rads, rads, rads);
-			wardShader.SetValue(RPR_MATERIAL_INPUT_ROTATION, radians);
+			specularShader.SetValue(RPR_MATERIAL_INPUT_ROTATION, radians);
+		
 
-			wardShader.SetValue(RPR_MATERIAL_INPUT_ROUGHNESS_X, spreadX);
-			wardShader.SetValue(RPR_MATERIAL_INPUT_ROUGHNESS_Y, spreadY);
-
-			result = materialSystem.ShaderBlend(diffuseShader, wardShader, 0.5);
+			result = materialSystem.ShaderBlend(diffuseShader, specularShader, 0.5);
 		} break;
 		case MayaLayeredShader:
 			// TODO

--- a/FireRender.Maya.Src/FireMaya.cpp
+++ b/FireRender.Maya.Src/FireMaya.cpp
@@ -1722,10 +1722,7 @@ frw::Shader FireMaya::Scope::ParseShader(MObject node)
 				mayaSpreadY = 98.0;
 			}
 
-			frw::Value roughnessX = materialSystem.ValueMul(roughness, 1.0 - mayaSpreadX / 100.0);
-			frw::Value roughnessY = materialSystem.ValueMul(roughness, 1.0 - mayaSpreadY / 100.0);
-			
-			frw::Value anisotropic = materialSystem.ValueSub(mayaSpreadY, mayaSpreadX);
+			frw::Value anisotropic = materialSystem.ValueSub(mayaSpreadX, mayaSpreadY);
 			anisotropic = materialSystem.ValueDiv(anisotropic, frw::Value(100.0));
 			specularShader.SetValue(RPR_MATERIAL_INPUT_ANISOTROPIC, anisotropic);
 

--- a/FireRender.Maya.Src/FireRenderImportExportXML.cpp
+++ b/FireRender.Maya.Src/FireRenderImportExportXML.cpp
@@ -1121,9 +1121,6 @@ MObject FireRenderXmlImportCmd::createShadingNode(MString materialName, std::map
 		case frw::ShaderTypeEmissive:
 			matType = FireMaya::Material::kEmissive;
 			break;
-		case frw::ShaderTypeWard:
-			matType = FireMaya::Material::kWard;
-			break;
 		case frw::ShaderTypeOrenNayer:
 			matType = FireMaya::Material::kOrenNayar;
 			break;

--- a/FireRender.Maya.Src/FireRenderMaterial.cpp
+++ b/FireRender.Maya.Src/FireRenderMaterial.cpp
@@ -31,10 +31,7 @@ namespace
 		MObject normalMap;
 		MObject refractiveIndex;
 		MObject roughness;
-		MObject roughnessX;
-		MObject roughnessY;
 		MObject wattsPerSQM;
-		MObject rotation;
 
 		MObject disableSwatch;
 		MObject swatchIterations;
@@ -68,7 +65,6 @@ MStatus FireMaya::Material::initialize()
 	eAttr.addField("Refract", kRefract);
 	eAttr.addField("Transparent", kTransparent);
 	eAttr.addField("Emissive", kEmissive);
-	eAttr.addField("Ward", kWard);
 	eAttr.addField("Oren-Nayar", kOrenNayar);
 	eAttr.addField("Diffuse Refraction", kDiffuseRefraction);
 	eAttr.addField("Pass Through", kPassThrough);
@@ -104,21 +100,6 @@ MStatus FireMaya::Material::initialize()
 	nAttr.setMax(10000000.0);
 	nAttr.setSoftMax(100.0);
 
-	Attribute::roughnessX = nAttr.create("roughnessX", "rgX", MFnNumericData::kFloat, 0.5);
-	MAKE_INPUT(nAttr);
-	nAttr.setDefault(0.5);
-	nAttr.setSoftMin(0.0);
-	nAttr.setSoftMax(1.0);
-
-	Attribute::roughnessY = nAttr.create("roughnessY", "rgY", MFnNumericData::kFloat, 0.5);
-	MAKE_INPUT(nAttr);
-	nAttr.setDefault(0.5);
-	nAttr.setSoftMin(0.0);
-	nAttr.setSoftMax(1.0);
-
-	Attribute::rotation = nAttr.create("rotation", "rt", MFnNumericData::kFloat, 0.0);
-	MAKE_INPUT(nAttr);
-
 	// output color
 	Attribute::output = nAttr.createColor("outColor", "oc");
 	MAKE_OUTPUT(nAttr);
@@ -142,9 +123,6 @@ MStatus FireMaya::Material::initialize()
 	CHECK_MSTATUS(addAttribute(Attribute::refractiveIndex));
 	CHECK_MSTATUS(addAttribute(Attribute::roughness));
 	CHECK_MSTATUS(addAttribute(Attribute::wattsPerSQM));
-	CHECK_MSTATUS(addAttribute(Attribute::roughnessX));
-	CHECK_MSTATUS(addAttribute(Attribute::roughnessY));
-	CHECK_MSTATUS(addAttribute(Attribute::rotation));
 
 	CHECK_MSTATUS(addAttribute(Attribute::output));
 	CHECK_MSTATUS(addAttribute(Attribute::outputAlpha));
@@ -159,9 +137,6 @@ MStatus FireMaya::Material::initialize()
 	CHECK_MSTATUS(attributeAffects(Attribute::refractiveIndex, Attribute::output));
 	CHECK_MSTATUS(attributeAffects(Attribute::roughness, Attribute::output));
 	CHECK_MSTATUS(attributeAffects(Attribute::wattsPerSQM, Attribute::output));
-	CHECK_MSTATUS(attributeAffects(Attribute::roughnessX, Attribute::output));
-	CHECK_MSTATUS(attributeAffects(Attribute::roughnessY, Attribute::output));
-	CHECK_MSTATUS(attributeAffects(Attribute::rotation, Attribute::output));
 
 	return MS::kSuccess;
 }
@@ -241,7 +216,6 @@ frw::Shader FireMaya::Material::GetShader(Scope& scope)
 		{ kRefract, frw::ShaderTypeRefraction },
 		{ kTransparent, frw::ShaderTypeTransparent },
 		{ kEmissive, frw::ShaderTypeEmissive },
-		{ kWard, frw::ShaderTypeWard },
 		{ kOrenNayar, frw::ShaderTypeOrenNayer },
 		{ kDiffuseRefraction, frw::ShaderTypeDiffuseRefraction },
 		{ kPassThrough, frw::ShaderTypeFlatColor }
@@ -265,9 +239,6 @@ frw::Shader FireMaya::Material::GetShader(Scope& scope)
 		{ Attribute::color, RPR_MATERIAL_INPUT_COLOR },
 		{ Attribute::normalMap, RPR_MATERIAL_INPUT_NORMAL },
 		{ Attribute::roughness, RPR_MATERIAL_INPUT_ROUGHNESS },
-		{ Attribute::roughnessX, RPR_MATERIAL_INPUT_ROUGHNESS_X },
-		{ Attribute::roughnessY, RPR_MATERIAL_INPUT_ROUGHNESS_Y },
-		{ Attribute::rotation, RPR_MATERIAL_INPUT_ROTATION },
 		{ Attribute::refractiveIndex, RPR_MATERIAL_INPUT_IOR }
 	};
 

--- a/FireRender.Maya.Src/FireRenderMaterial.h
+++ b/FireRender.Maya.Src/FireRenderMaterial.h
@@ -28,7 +28,6 @@ namespace FireMaya
 			kRefract,
 			kTransparent,
 			kEmissive,
-			kWard,
 			kOrenNayar,
 			kDiffuseRefraction,	// 1.7.16
 			kPassThrough,

--- a/FireRender.Maya.Src/FireRenderSurfaceOverride.cpp
+++ b/FireRender.Maya.Src/FireRenderSurfaceOverride.cpp
@@ -81,8 +81,6 @@ MString FireRenderMaterialNodeOverride::fragmentName() const
 		case FireMaya::Material::kMicrofacet:
 		case FireMaya::Material::kOrenNayar:
 			return "mayaBlinnSurface";
-		case FireMaya::Material::kWard:
-			return "mayaAnisotropicSurface";
 	}
 	return "mayaBlinnSurface";
 }
@@ -113,13 +111,6 @@ void FireRenderMaterialNodeOverride::updateShader(MHWRender::MShaderInstance& sh
 			float diff[] = { 0.f, 0.f, 0.f };
 			result = shader.setParameter("color", diff);
 			result = shader.setParameter("specularRollOff", 1.0f);
-		}
-		break;
-
-		case FireMaya::Material::kWard:
-		{
-			float diff[] = { 0.f, 0.f, 0.f };
-			result = shader.setParameter("color", diff);
 		}
 		break;
 
@@ -154,7 +145,6 @@ MString FireRenderMaterialNodeOverride::primaryColorParameter() const
 {
 	switch (getType())
 	{
-		case FireMaya::Material::kWard:
 		case FireMaya::Material::kMicrofacet:
 			return "specularColor";
 		case FireMaya::Material::kDiffuse:

--- a/FireRender.Maya.Src/frWrap.cpp
+++ b/FireRender.Maya.Src/frWrap.cpp
@@ -94,7 +94,6 @@ namespace frw
 			NODE_ENTRY(ShaderTypeMicrofacetRefraction),
 			NODE_ENTRY(ShaderTypeTransparent),
 			NODE_ENTRY(ShaderTypeEmissive),
-			NODE_ENTRY(ShaderTypeWard),
 			NODE_ENTRY(ShaderTypeBlend),
 			NODE_ENTRY(ShaderTypeOrenNayer),
 			NODE_ENTRY(ShaderTypeDiffuseRefraction),

--- a/FireRender.Maya.Src/frWrap.h
+++ b/FireRender.Maya.Src/frWrap.h
@@ -182,7 +182,6 @@ namespace frw
 		ShaderTypeMicrofacetRefraction = RPR_MATERIAL_NODE_MICROFACET_REFRACTION,
 		ShaderTypeTransparent = RPR_MATERIAL_NODE_TRANSPARENT,
 		ShaderTypeEmissive = RPR_MATERIAL_NODE_EMISSIVE,
-		ShaderTypeWard = RPR_MATERIAL_NODE_WARD,
 		ShaderTypeBlend = RPR_MATERIAL_NODE_BLEND,
 		ShaderTypeStandard = RPR_MATERIAL_NODE_UBERV2,
 		ShaderTypeOrenNayer = RPR_MATERIAL_NODE_ORENNAYAR,
@@ -190,7 +189,8 @@ namespace frw
 		ShaderTypeAdd = RPR_MATERIAL_NODE_ADD,
 		ShaderTypeVolume = RPR_MATERIAL_NODE_VOLUME,
 		ShaderTypeFlatColor = RPR_MATERIAL_NODE_PASSTHROUGH,
-		ShaderTypeToon = RPR_MATERIAL_NODE_TOON_CLOSURE
+		ShaderTypeToon = RPR_MATERIAL_NODE_TOON_CLOSURE,
+		ShaderTypeMicrofacetAnisotropicReflection = RPR_MATERIAL_NODE_MICROFACET_ANISOTROPIC_REFLECTION
 	};
 
 	enum ContextParameterType

--- a/FireRender.Maya.Src/scripts/AERPRMaterialTemplate.mel
+++ b/FireRender.Maya.Src/scripts/AERPRMaterialTemplate.mel
@@ -15,27 +15,27 @@ global proc AERPRMaterialType(string $nodeName)
 	int $disable[];
 	int $type = `getAttr ($nodeName + ".type")`;
 	if ($type == 0) {			// diffuse
-		$disable = {0, 1, 1, 1, 0, 1, 1, 1};
+		$disable = {0, 1, 1, 1, 0};
 	} else if ($type == 1) {	// microfacet
-		$disable = {0, 0, 0, 1, 0, 1, 1, 1};
+		$disable = {0, 0, 0, 1, 0};
 	} else if ($type == 2) {	// microfacet refract
-		$disable = {0, 0, 0, 1, 0, 1, 1, 1};
+		$disable = {0, 0, 0, 1, 0};
 	} else if ($type == 3) {	// reflect
-		$disable = {0, 1, 1, 1, 0, 1, 1, 1};
+		$disable = {0, 1, 1, 1, 0};
 	} else if ($type == 4) {	// refract
-		$disable = {0, 1, 0, 1, 0, 1, 1, 1};
+		$disable = {0, 1, 0, 1, 0};
 	} else if ($type == 5) {	// transparent
-		$disable = {0, 1, 1, 1, 1, 1, 1, 1};
+		$disable = {0, 1, 1, 1, 1};
 	} else if ($type == 6) {    // emissive
-		$disable = {0, 1, 1, 0, 1, 1, 1, 1};
+		$disable = {0, 1, 1, 0, 1};
 	} else if ($type == 7) {    // ward
-		$disable = {0, 1, 0, 1, 0, 0, 0, 0};
+		$disable = {0, 1, 0, 1, 0};
 	} else if ($type == 8) {    // oren
-		$disable = {0, 0, 1, 1, 0, 1, 1, 1};
+		$disable = {0, 0, 1, 1, 0};
 	} else if ($type == 9) {    // diffuse refraction
-		$disable = {0, 0, 1, 1, 0, 1, 1, 1};
+		$disable = {0, 0, 1, 1, 0};
 	} else if ($type == 10) {    // passthrough
-		$disable = {0, 1, 1, 1, 1, 1, 1, 1};
+		$disable = {0, 1, 1, 1, 1};
 	}
 
 	editorTemplate -dimControl $nodeName "color"            $disable[0];
@@ -43,9 +43,6 @@ global proc AERPRMaterialType(string $nodeName)
 	editorTemplate -dimControl $nodeName "refractiveIndex"  $disable[2];
 	editorTemplate -dimControl $nodeName "wattsPerSqm"      $disable[3];
 	editorTemplate -dimControl $nodeName "normalMap"        $disable[4];
-	editorTemplate -dimControl $nodeName "roughnessX"       $disable[5];
-	editorTemplate -dimControl $nodeName "roughnessY"       $disable[6];
-	editorTemplate -dimControl $nodeName "rotation"         $disable[7];
 }
 
 global proc AERPRMaterialTemplate( string $nodeName )
@@ -66,11 +63,6 @@ global proc AERPRMaterialTemplate( string $nodeName )
 	editorTemplate -endLayout;
 	editorTemplate -beginLayout "Emission" -collapse 0;
 		editorTemplate -addControl "wattsPerSqm";
-	editorTemplate -endLayout;
-	editorTemplate -beginLayout "Ward" -collapse 0;
-		editorTemplate -addControl "roughnessX";
-		editorTemplate -addControl "roughnessY";
-		editorTemplate -addControl "rotation";
 	editorTemplate -endLayout;
 	editorTemplate -beginLayout "Normal Map" -collapse 0;
 		editorTemplate -addControl "normalMap";


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3117

PURPOSE: ward material node is not supported by core

EFFECT OF CHANGES: now ward node had been removed from maya rpr shader, and replaced with microfacet node in maya anisotropic shader