### PR TITLE
Add support for exporting frames with negative numbers

### DIFF
--- a/FireRender.Maya.Src/scripts/shelfCommands.mel
+++ b/FireRender.Maya.Src/scripts/shelfCommands.mel
@@ -230,10 +230,9 @@ global proc exportSceneRPR()
 			
 			intSliderGrp 
 				-label "First Frame" 
-				-field true 
-				-minValue 1 
-				-fieldMinValue 1 
-				-maxValue 100 
+				-field true
+			    -minValue -100 
+				-fieldMinValue (1 - $maxIntVal) 
 				-fieldMaxValue $maxIntVal 
 				-value 1 
 				-enable false 
@@ -245,8 +244,8 @@ global proc exportSceneRPR()
 			intSliderGrp 
 				-label "Last Frame" 
 				-field true 
-				-minValue 1 
-				-fieldMinValue 1 
+			    -minValue -100 
+				-fieldMinValue (1 - $maxIntVal)
 				-maxValue 100 
 				-fieldMaxValue $maxIntVal 
 				-value 60 


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3140

PURPOSE: Maya supports frames' numbers going below 0. This PR allows frames with negative numbers to be exported.

EFFECT FOR THE USER: It is now possible to export frames with negative numbers.