### PR TITLE
Add support for batch rendering frames with negative numbers

### DIFF
--- a/FireRender.Maya.Src/FireRenderCmd.cpp
+++ b/FireRender.Maya.Src/FireRenderCmd.cpp
@@ -595,7 +595,7 @@ MStatus FireRenderCmd::exportsGLTF(const MArgDatabase& argData)
 
 // -----------------------------------------------------------------------------
 MString FireRenderCmd::getOutputFilePath(const MCommonRenderSettingsData& settings,
-	unsigned int frame, const MString& camera, bool preview) const
+	 int frame, const MString& camera, bool preview) const
 {
 	// The base file name will be populated in the settings if the
 	// user has specified a custom file name, otherwise, it will be empty.

--- a/FireRender.Maya.Src/FireRenderCmd.h
+++ b/FireRender.Maya.Src/FireRenderCmd.h
@@ -108,7 +108,7 @@ private:
 
 	/** Get the output file path, with an optional frame for multi-frame renders. */
 	MString getOutputFilePath(const MCommonRenderSettingsData& settings,
-		unsigned int frame, const MString& camera, bool preview) const;
+		 int frame, const MString& camera, bool preview) const;
 
 	/** Return true if the specified file already exists. */
 	bool outputFileExists(const MString& filePath) const;


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3143

PURPOSE: Maya supports frames' numbers going below 0. This PR allows frames with negative numbers to be batch rendered.

EFFECT FOR THE USER: Frames with negative numbers now can be saved as pictures when using batch render.