### PR TITLE
Change default color for albedo to gray

### DIFF
--- a/FireRender.Maya.Src/FireRenderUtils.h
+++ b/FireRender.Maya.Src/FireRenderUtils.h
@@ -1084,15 +1084,23 @@ bool SetRampValues(MPlug& plug, const MayaDataContainer& values)
 	// get ramp from plug
 	MRampAttribute valueRamp(plug);
 
-	MIntArray interps(values.length(), MRampAttribute::kLinear);
-
 	unsigned int len = values.length();
-	MFloatArray positions(len, 0.0f);
-	for (unsigned int idx = 0; idx < len; ++idx)
-	{
-		positions[idx] = idx * 1.0f / (values.length() - 1);
-	}
 
+	MIntArray interps(len, MRampAttribute::kLinear);
+
+	MFloatArray positions(len, 0.0f);
+	if (len > 1)
+	{
+		for (unsigned int idx = 0; idx < len; ++idx)
+		{
+			positions[idx] = idx * 1.0f / (len - 1);
+		}
+	} else {
+		for (unsigned int idx = 0; idx < len; ++idx)
+		{
+			positions[idx] = 0;
+		}
+	}
 	MStatus status;
 	valueRamp.setRamp(values, positions, interps);
 	if (status != MS::kSuccess)

--- a/FireRender.Maya.Src/FireRenderUtils.h
+++ b/FireRender.Maya.Src/FireRenderUtils.h
@@ -1009,6 +1009,10 @@ bool SaveCtrlPoints(
 
 	// ensure correct input
 	unsigned int length = dataVals.length();
+	if (!length)
+	{
+		return false;
+	}
 	if ((length != positions.length()) || 
 		(length != interps.length()) || 
 		(length != indexes.length())

--- a/FireRender.Maya.Src/FireRenderUtils.h
+++ b/FireRender.Maya.Src/FireRenderUtils.h
@@ -1009,7 +1009,7 @@ bool SaveCtrlPoints(
 
 	// ensure correct input
 	unsigned int length = dataVals.length();
-	if (!length)
+	if (length == 0)
 	{
 		return false;
 	}

--- a/FireRender.Maya.Src/Volumes/FireRenderVolumeLocator.cpp
+++ b/FireRender.Maya.Src/Volumes/FireRenderVolumeLocator.cpp
@@ -85,7 +85,7 @@ void FireRenderVolumeLocator::postConstructor()
 	// - this happens despite api documentation saying that default control point is created automatically - it's not.
 	// - Since we need to set these values anyway, we set them to what user most likely wants
 	MPlug albedoRampPlug(thisMObject(), RPRVolumeAttributes::albedoRamp);
-	const float albedoSrc[][4] = { 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f };
+	const float albedoSrc[][4] = { 0.5f, 0.5f, 0.5f, 1.0f, 0.5f, 0.5f, 0.5f, 1.0f };
 	MColorArray albedoValues(albedoSrc, 2);
 	SetRampValues(albedoRampPlug, albedoValues);
 

--- a/FireRender.Maya.Src/Volumes/FireRenderVolumeLocator.cpp
+++ b/FireRender.Maya.Src/Volumes/FireRenderVolumeLocator.cpp
@@ -85,7 +85,7 @@ void FireRenderVolumeLocator::postConstructor()
 	// - this happens despite api documentation saying that default control point is created automatically - it's not.
 	// - Since we need to set these values anyway, we set them to what user most likely wants
 	MPlug albedoRampPlug(thisMObject(), RPRVolumeAttributes::albedoRamp);
-	const float albedoSrc[][4] = { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+	const float albedoSrc[][4] = { 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f };
 	MColorArray albedoValues(albedoSrc, 2);
 	SetRampValues(albedoRampPlug, albedoValues);
 


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3299

PURPOSE: Albedo value works as the ratio between scattering and emission, so if setting albedo color to black, only emission (absorption) happens. and if setting it to white, only scattering happens (emission color is not shown). Gray allows both to apply.

EFFECT FOR THE USER: Default albedo gradient goes from gray to white instead of black to white.