### PR TITLE
Fallback to GPU when trying to render with CPU with HybridPro

### DIFF
--- a/FireRender.Maya.Src/Context/HybridProContext.cpp
+++ b/FireRender.Maya.Src/Context/HybridProContext.cpp
@@ -71,7 +71,8 @@ rpr_int HybridProContext::CreateContextInternal(rpr_creation_flags createFlags, 
 	{
 		createFlags = createFlags & ~RPR_CREATION_FLAGS_ENABLE_CPU;
 		createFlags = createFlags | RPR_CREATION_FLAGS_ENABLE_GPU0;
-		MGlobal::displayError("CPU mode not supported for HybridPro. Falling back to GPU.");
+		MGlobal::displayWarning("CPU mode not supported for HybridPro. Falling back to GPU.");
+		MGlobal::displayWarning("If render stamp is enabled, please change render device to GPU");
 	}
 
 	std::vector<rpr_context_properties> ctxProperties;

--- a/FireRender.Maya.Src/Context/HybridProContext.cpp
+++ b/FireRender.Maya.Src/Context/HybridProContext.cpp
@@ -57,16 +57,23 @@ rpr_int HybridProContext::CreateContextInternal(rpr_creation_flags createFlags, 
 
 	auto cachePath = getShaderCachePath();
 
-	bool useThread = (createFlags & RPR_CREATION_FLAGS_ENABLE_CPU) == RPR_CREATION_FLAGS_ENABLE_CPU;
+	bool useCpu = (createFlags & RPR_CREATION_FLAGS_ENABLE_CPU) == RPR_CREATION_FLAGS_ENABLE_CPU;
 
-	DebugPrint("* Creating Context: %d (0x%x) - useThread: %d", createFlags, createFlags, useThread);
+	DebugPrint("* Creating Context: %d (0x%x) - useThread: %d", createFlags, createFlags, useCpu);
 
 	if (isMetalOn() && !(createFlags & RPR_CREATION_FLAGS_ENABLE_CPU))
 	{
 		createFlags = createFlags | RPR_CREATION_FLAGS_ENABLE_METAL;
 	}
 
-	// setup CPU thread count
+	// fallback to GPU - CPU not supported
+	if (useCpu)
+	{
+		createFlags = createFlags & ~RPR_CREATION_FLAGS_ENABLE_CPU;
+		createFlags = createFlags | RPR_CREATION_FLAGS_ENABLE_GPU0;
+		MGlobal::displayError("CPU mode not supported for HybridPro. Falling back to GPU.");
+	}
+
 	std::vector<rpr_context_properties> ctxProperties;
 	ctxProperties.push_back((rpr_context_properties)RPR_CONTEXT_CREATEPROP_HYBRID_ENABLE_PER_FACE_MATERIALS);
 	const bool perFaceEnabled = true;

--- a/FireRender.Maya.Src/scripts/RenderQualityTab.mel
+++ b/FireRender.Maya.Src/scripts/RenderQualityTab.mel
@@ -21,10 +21,14 @@ proc createFinalRenderQualityPart()
 	//
 	if (isWindowsRunning())
 	{
+	string $visScrpt = "int $isFinal = 1; onRenderQualityChanged($isFinal);";
+
 		frameLayout -label "Final Render Quality" -cll true -cl 0 fireRenderQualityFrame;
 		attrControlGrp
 			-label "Render Quality"
-			-attribute "RadeonProRenderGlobals.renderQualityFinalRender";
+			-attribute "RadeonProRenderGlobals.renderQualityFinalRender"
+			-changeCommand $visScrpt;
+			
 		setParent ..;
 	}
 
@@ -96,10 +100,13 @@ proc createViewportRenderQualityPart()
 {
 	if (isWindowsRunning())
 	{
+	string $visScrpt = "int $isFinal = 0; onRenderQualityChanged($isFinal);";
+
 		frameLayout -label "Viewport Render Quality" -cll true -cl 0 fireRenderViewportQualityFrame;
 		attrControlGrp
 			 -label "Render Quality"
-			 -attribute "RadeonProRenderGlobals.renderQualityViewport";
+			 -attribute "RadeonProRenderGlobals.renderQualityViewport"
+			 -changeCommand $visScrpt;
 		setParent ..;
 	}
 
@@ -157,4 +164,52 @@ global proc updateOOCUIProduction()
 global proc updateQualityTab()
 {
 
+}
+
+source "createFireRenderGlobalsTab.mel";
+
+global proc onRenderQualityChanged(int $isFinal)
+{
+	  // $isFinal - $isFinalRender 0 - cpu 0 - isGpu
+	  string $cpuCtrlName = getDeviceCheckBoxCtrlName($isFinal, 0, 0);
+
+	  int $renderQual;
+	  int $disableCpu;
+	  if($isFinal)
+	  {
+		$renderQual = `getAttr RadeonProRenderGlobals.renderQualityFinalRender`;
+		$disableCpu = $renderQual == 5 ? 1 : 0; // 5 - RenderQualityHybridPro;
+	  } else { // not final --> viewport
+		$renderQual = `getAttr RadeonProRenderGlobals.renderQualityViewport`;
+		$disableCpu = $renderQual == 0 ? 1 : 0; // 0 - Viewport HybridPro; 4 - NorthStar
+	  }  
+	  
+	  if($disableCpu)
+	  {
+	  	string $gpuCtrlName = getDeviceCheckBoxCtrlName($isFinal, 0, 1);
+
+		// we need catchQuiet in case System tab is not loaded yet - user did not open it
+		catchQuiet(`
+	  	checkBoxGrp
+	  		-e
+	  		-v1 0 // checked
+	  		-en 0 // enabled 
+	  		$cpuCtrlName
+	  		`);
+
+		catchQuiet(`
+	  	checkBoxGrp
+	  		-e
+	  		-v1 1
+	  		$gpuCtrlName
+	  		`);
+
+	  } else {
+	    catchQuiet(`
+	  	checkBoxGrp
+	  		-e
+	  		-en 1
+	  		$cpuCtrlName
+			`);	
+	  }
 }

--- a/FireRender.Maya.Src/scripts/createFireRenderGlobalsTab.mel
+++ b/FireRender.Maya.Src/scripts/createFireRenderGlobalsTab.mel
@@ -29,7 +29,7 @@ proc string getDevicesUsingVarName(int $isFinalRender)
 }
 
 // control names handling
-proc string getDeviceCheckBoxCtrlName(int $isFinalRender, int $index, int $isGPU)
+global proc string getDeviceCheckBoxCtrlName(int $isFinalRender, int $index, int $isGPU)
 {
     if ($isGPU > 0)
     {
@@ -76,14 +76,26 @@ global proc deviceTypeChangedUI(int $isFinalRender)
 
 	int $forceUseCPU = ($devicesInUse == 0);
 
+	// ensure at least one device is selected
     string $cpuCtrlName = getDeviceCheckBoxCtrlName($isFinalRender, 0, 0);
+	int $isCpuEnabled = `checkBoxGrp -q -en $cpuCtrlName`;
 	if($forceUseCPU)
 	{
-		checkBoxGrp
-			-e
-			-v1 1
-			$cpuCtrlName
-			;
+		if($isCpuEnabled)
+		{
+			checkBoxGrp
+				-e
+				-v1 1
+				$cpuCtrlName
+				;
+		} else { // at least one gpu expected
+			string $gpuCtrlName = getDeviceCheckBoxCtrlName($isFinalRender, 0, 1);
+			checkBoxGrp
+				-e
+				-v1 1
+				$gpuCtrlName
+				;
+		}
 	}
 
 	int $useCPU = `checkBoxGrp -q -v1 $cpuCtrlName`;
@@ -184,6 +196,9 @@ global proc createRenderResourcesFrame(string $parent, int $isFinalRender)
 	setUITemplate -popTemplate;
 
 	deviceTypeChangedUI($isFinalRender);
+
+	// ensure correct device is selected on startup
+	onRenderQualityChanged($isFinalRender);
 }
 
 global proc createFireRenderGlobalsFrame(string $parent)


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3229

PURPOSE: HybridPro does not support rendering with CPU. This PR allows the user to select only GPU when HybridPro is chosen. CPU option is grayed out

EFFECT FOR THE USER: HybridPro renders using GPU. CPU option is grayed out. Unknown error no longer occurs when trying to render with CPU.