### PR TITLE
Disable tile rendering for contour

### DIFF
--- a/FireRender.Maya.Src/scripts/RenderEffectsTab.mel
+++ b/FireRender.Maya.Src/scripts/RenderEffectsTab.mel
@@ -278,6 +278,9 @@ global proc onUpdateContour()
 	attrControlGrp -edit -enable $enabled contourUVThreshold;
 	attrControlGrp -edit -enable $enabled contourAntialiasing;
 	attrControlGrp -edit -enable $enabled contourIsDebugEnabled;
+
+	// enable or disable tile rendering
+	FinalRender_TileRenderingReactToContourChanged($enabled);
 }
 
 global proc createFireRenderMotionBlurFrame(string $parent)

--- a/FireRender.Maya.Src/scripts/RenderSamplingTab.mel
+++ b/FireRender.Maya.Src/scripts/RenderSamplingTab.mel
@@ -19,26 +19,27 @@ global proc FinalRender_onTileRenderChanged()
 }
 
 // disable tile rendering for contour
-global proc FinalRender_TileRenderingReactToLayerChange()
+global proc FinalRender_TileRenderingReactToContourChanged(int $enabled)
 {
-	string $currentRenderLayer = currentRenderLayerLabel();
-	if($currentRenderLayer == "contour")
+	if($enabled)
 	{
 		setAttr RadeonProRenderGlobals.tileRenderEnabled 0;
+		catchQuiet(`
 		checkBoxGrp
 				-e
 				-v1 0
 				-en 0
 				tileRenderEnabled
-				;
+				`);
 	} else 
 	{
+		catchQuiet(`
 		checkBoxGrp
 				-e
 				-v1 0
 				-en 1
 				tileRenderEnabled
-				;
+				`);
 	}
 }
 
@@ -61,13 +62,11 @@ global proc createRenderSamplingTab()
 		-attribute "RadeonProRenderGlobals.tileRenderEnabled"
         -cc FinalRender_onTileRenderChanged
         tileRenderEnabled
-	; 
-	
-	// subscribe to render layer changing
-	scriptJob -event "renderLayerManagerChange" ("FinalRender_TileRenderingReactToLayerChange");
+	;
 
 	// react to initial value
-	FinalRender_TileRenderingReactToLayerChange();
+	$enabled = `getAttr RadeonProRenderGlobals.contourIsEnabled`;
+	FinalRender_TileRenderingReactToContourChanged($enabled);
 
     attrControlGrp
     	-label "Tile X"

--- a/FireRender.Maya.Src/scripts/RenderSamplingTab.mel
+++ b/FireRender.Maya.Src/scripts/RenderSamplingTab.mel
@@ -18,6 +18,29 @@ global proc FinalRender_onTileRenderChanged()
     attrControlGrp -e -en $enabled tileRenderY;
 }
 
+// disable tile rendering for contour
+global proc FinalRender_TileRenderingReactToLayerChange()
+{
+	string $currentRenderLayer = currentRenderLayerLabel();
+	if($currentRenderLayer == "contour")
+	{
+		setAttr RadeonProRenderGlobals.tileRenderEnabled 0;
+		checkBoxGrp
+				-e
+				-v1 0
+				-en 0
+				tileRenderEnabled
+				;
+	} else 
+	{
+		checkBoxGrp
+				-e
+				-v1 0
+				-en 1
+				tileRenderEnabled
+				;
+	}
+}
 
 global proc createRenderSamplingTab()
 {
@@ -34,11 +57,17 @@ global proc createRenderSamplingTab()
     columnLayout -cat left 20;
 
     attrControlGrp
-    	-label "Tile Render Enabled"
+    	-label "Tile Render"
 		-attribute "RadeonProRenderGlobals.tileRenderEnabled"
         -cc FinalRender_onTileRenderChanged
         tileRenderEnabled
-	;  
+	; 
+	
+	// subscribe to render layer changing
+	scriptJob -event "renderLayerManagerChange" ("FinalRender_TileRenderingReactToLayerChange");
+
+	// react to initial value
+	FinalRender_TileRenderingReactToLayerChange();
 
     attrControlGrp
     	-label "Tile X"


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3346

PURPOSE: Rendering contour with tile rendering now shows some artifacts, but this tile rendering is not needed for contour rendering. So, it’s better to disable tile rendering for contour.

EFFECT FOR THE USER: Tile rendering cannot be selected in the ui when contour layer is selected as it is grayed out.