### PR TITLE
Stop writing out not needed AOVs for contour rendering

### DIFF
--- a/FireRender.Maya.Src/FireRenderAOV.cpp
+++ b/FireRender.Maya.Src/FireRenderAOV.cpp
@@ -326,6 +326,13 @@ bool FireRenderAOV::writeToFile(FireRenderContext& context, const MString& fileP
 	if (!active || !pixels || m_region.isZeroArea())
 		return false;
 
+	// do not write Shading normal, Object ID, Material Index, and UV for contour as they are overwritten per iteration
+	bool isContour = context.Globals().contourIsEnabled;
+	if (isContour && (id == RPR_AOV_MATERIAL_ID || id == RPR_AOV_SHADING_NORMAL || id == RPR_AOV_OBJECT_ID || id == RPR_AOV_UV))
+	{
+		return true;
+	}
+
 	// Use the incoming path if only outputting the color AOV,
 	// otherwise, get a new path that includes a folder for the AOV.
 	MString path = colorOnly ? filePath : getOutputFilePath(filePath);


### PR DESCRIPTION
JIRA TICKET: RPRMAYA-3345

PURPOSE: Contour rendering requires 4 AOVs enabled, ‘Shading normal’, ‘Object ID’, ‘Material Index’, and ‘UV’.
However, we don’t need to write them out as output files because these AOVs are overwritten per iteration, which makes them unusable for users.

So, it’s better not to write out these AOVs even if contour mode is enabled.

EFFECT FOR THE USER: ‘Shading normal’, ‘Object ID’, ‘Material Index’, and ‘UV’ AOVs do not get written anymore with contour rendering enabled.